### PR TITLE
storagezone: use d.Partial in Update instead of revertUpdateValues

### DIFF
--- a/internal/provider/resource_storagezone.go
+++ b/internal/provider/resource_storagezone.go
@@ -272,14 +272,11 @@ func resourceStorageZoneUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 	updateErr := clt.StorageZone.Update(ctx, id, storageZone)
 	if updateErr != nil {
-		// if our update failed then revert our values to their original
-		// state so that we can run an apply again.
-		revertErr := revertUpdateValues(d)
-
-		if revertErr != nil {
-			return diagsErrFromErr("updating storage zone via API failed", revertErr)
-		}
-
+		// The storagezone contains fields /custom_404_file_path) that are only updated by the
+		// provider and not retrieved via ReadContext(). This causes that we run into the bug
+		// https://github.com/hashicorp/terraform-plugin-sdk/issues/476.
+		// As workaround d.Partial(true) is called.
+		d.Partial(true)
 		return diagsErrFromErr("updating storage zone via API failed", updateErr)
 	}
 
@@ -364,23 +361,6 @@ func storageZoneToResource(sz *bunny.StorageZone, d *schema.ResourceData) error 
 		return err
 	}
 	if err := setStrSet(d, keyReplicationRegions, sz.ReplicationRegions, ignoreOrderOpt, caseInsensitiveOpt); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func revertUpdateValues(d *schema.ResourceData) error {
-	o, _ := d.GetChange(keyOriginURL)
-	if err := d.Set(keyOriginURL, o); err != nil {
-		return err
-	}
-	o, _ = d.GetChange(keyCustom404FilePath)
-	if err := d.Set(keyCustom404FilePath, o); err != nil {
-		return err
-	}
-	o, _ = d.GetChange(keyRewrite404To200)
-	if err := d.Set(keyRewrite404To200, o); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The behavior described in https://github.com/5-stones/terraform-provider-bunny/pull/1#discussion_r898134629 made me very suspicious because I did not encounter the behaviour before and other providers also do not revert the state after a failed update. 

I turned out that this is an upstream bug: https://github.com/hashicorp/terraform-plugin-sdk/issues/476

```
storagezone: use d.Partial in Update instead of revertUpdateValues

That after a failed update changes to the resource are still applied is a know
bug (https://github.com/hashicorp/terraform-plugin-sdk/issues/476).
It affects attributes that are not retrieved via the Get function and set only
by the provider.
custom_404_file_path is such a field.
As workaround d.Partial() can be called.
This is more simple then the revertUpdateValues() implementation.

-------------------------------------------------------------------------------
tests: add testcase that ensures failed update does not change current state

-------------------------------------------------------------------------------
```